### PR TITLE
refactor: multiplayer server mod version number

### DIFF
--- a/docker/mods/Always On Server/manifest.json
+++ b/docker/mods/Always On Server/manifest.json
@@ -1,10 +1,10 @@
 {
   "Name": "Stardew Multiplayer Server",
   "Author": "funny-snek & Zuberii & moy",
-  "Version": "1.6.0",
+  "Version": "1.0.2",
   "Description": "A Headless server mod.",
   "UniqueID": "moy.Always_On_Server",
   "EntryDll": "Stardew-Multiplayer-Server.dll",
   "MinimumApiVersion": "4.0",
-  "UpdateKeys": [ "" ]
+  "UpdateKeys": [""]
 }


### PR DESCRIPTION
The version of Stardew Multiplayer Server Mod was incorrectly set to the Stardew game version number. Update manifest to the actual mod version of 1.0.2.