### PR TITLE
Fix #24 add -noxdamage to VNC

### DIFF
--- a/docker-compose-steam.yml
+++ b/docker-compose-steam.yml
@@ -20,7 +20,8 @@ services:
       - VNC_PASSWORD=insecure
       - DISPLAY_HEIGHT=900
       - DISPLAY_WIDTH=1200
-
+      - X11VNC_EXTRA_OPTS=-noxdamage -reopen -forever
+  
       # Always On Server mod
       ## Removing this will probably defeat the point of ever using this?
       - ENABLE_ALWAYSONSERVER_MOD=${ENABLE_ALWAYSONSERVER_MOD-true}


### PR DESCRIPTION
This is a rather nebulous issue. It is possible that adding the `steamcmd` updated some library that causes this issue on the x11/VNC server. Very likely to what is reported on this [Arch wiki (3.4)](https://wiki.archlinux.org/title/x11vnc#Session_closes_unexpectedly). 

To fix the #24 it I've added 3 flags to the `x11vnc` launch `-noxdamage -reopen -forever`, it is very likely that only `-noxdamage` is required, buy I've added other to make sure that the `x11vnc` doesn't have any additional surprise. Luckily the base image allow us to add additional flags using `X11VNC_EXTRA_OPTS` environment variable (very deeply documented only on some old change log). 

Drawback: removing xdamage theoretically should increase server bandwith usage and latency.


Obs 1.: On my personal image I have also upgraded the `x11vnc` from 9.14 to 9.16, but it is not necessary and I will avoid to add an additional layer to the Dockerfile unless it is really necessary. 

Obs 2.: Maybe  we could add those flags to the GOG flag.