### PR TITLE
Fixes to steam locale and update policy

### DIFF
--- a/docker/Dockerfile-steam
+++ b/docker/Dockerfile-steam
@@ -25,6 +25,13 @@ RUN wget https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz 
     tar -xzvf steamcmd.tar.gz -C /data/steamcmd && \
     cd /data/steamcmd
 
+## Generate en_US.UTF-8 locale require by steam incase missing
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+        dpkg-reconfigure --frontend=noninteractive locales
+
+## Update steam to prevent steamguard code timeout
+RUN /data/steamcmd/steamcmd.sh +quit
+
 ## Don't set the arg earlier, if you need to rebuild the container
 ## it will cache up to here when you change the ENV VAR
 ARG STEAM_GUARD


### PR DESCRIPTION
I've added a small section to correct to issues I had when using this server:

1. Steam CMD requires the locale en_US.UTF-8 to be installed to function correctly; I only had en_UK as I'm UK based so the first fix generates this locale so that non-us language users can still use the server.

2. Steam CMD would require an update upon first launch that took a non-trivial amount of time. Typically this lead to the steam guard code rotating before it was used, and thus creating a failed login attempt. I've added an initial call before the login step to allow the update to occure before the guard code is added to the container.