### PR TITLE
Add volume for mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ for more info.)
 - [TimeSpeed](https://www.nexusmods.com/stardewvalley/mods/169) (Default: Off)
 - [Unlimited Players](https://www.nexusmods.com/stardewvalley/mods/2213) (Default: On)
 
+Add any additional mods to the `docker/mods` directory.
+
 ## Troubleshooting
 
 ### Waiting for Day to End

--- a/docker-compose-gog.yml
+++ b/docker-compose-gog.yml
@@ -130,6 +130,8 @@ services:
       - ./valley_saves:/config/xdg/config/StardewValley/Saves
       # If you'd like to set an existing savegame before the first start otherwise this file will be edited when starting the first game
       - ./configs/autoload.json:/data/Stardew/game/Mods/AutoLoadGame/config.json
+      # Add mods here
+      - ./docker/mods:/data/Stardew/game/Mods/
     # deploy:
     #   ## The container is CPU hungry, you can limit using this block
     #   ## If you don't plan to play using VNC, 1 core should be enough to host for others

--- a/docker-compose-steam.yml
+++ b/docker-compose-steam.yml
@@ -140,6 +140,8 @@ services:
       - ./valley_saves:/config/xdg/config/StardewValley/Saves
       # If you'd like to set an existing savegame before the first start otherwise this file will be edited when starting the first game
       - ./configs/autoload.json:/data/Stardew/game/Mods/AutoLoadGame/config.json
+      # Add mods here
+      - ./docker/mods:/data/Stardew/game/Mods/
     # deploy:
     #   ## The container is CPU hungry, you can limit using this block
     #   ## If you don't plan to play using VNC, 1 core should be enough to host for others

--- a/docker/Dockerfile-steam
+++ b/docker/Dockerfile-steam
@@ -51,7 +51,7 @@ RUN wget -qO dotnet.tar.gz https://download.visualstudio.microsoft.com/download/
      rm dotnet.tar.gz &&\
      ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
-RUN wget --user-agent="Mozilla" https://github.com/Pathoschild/SMAPI/releases/download/4.0.8/SMAPI-4.0.8-installer.zip -qO /data/nexus.zip && \
+RUN wget --user-agent="Mozilla" https://github.com/Pathoschild/SMAPI/releases/download/4.1.9/SMAPI-4.1.9-installer.zip -qO /data/nexus.zip && \
     unzip /data/nexus.zip -d /data/nexus/ && \
     SMAPI_INSTALLER=$(find /data/nexus -name 'SMAPI*.*Installer' -type f -path "*/SMAPI * installer/internal/linux/*" | head -n 1) && \
     /bin/bash -c "SMAPI_NO_TERMINAL=true SMAPI_USE_CURRENT_SHELL=true echo -e '2\n\n' | \"$SMAPI_INSTALLER\" --install --game-path \"$GAME_PATH\"" || :


### PR DESCRIPTION
Previously, after adding mods, the docker image would need to be rebuilt. Adding a volume to the docker-compose file allows users to add mods and simply restart the container which saves a significant amount of time.

Additionally, I updated SMAPI to 4.1.9