### PR TITLE
Update SMAPI to latest

### DIFF
--- a/docker/Dockerfile-steam
+++ b/docker/Dockerfile-steam
@@ -51,7 +51,7 @@ RUN wget -qO dotnet.tar.gz https://download.visualstudio.microsoft.com/download/
      rm dotnet.tar.gz &&\
      ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
-RUN wget --user-agent="Mozilla" https://github.com/Pathoschild/SMAPI/releases/download/4.0.8/SMAPI-4.0.8-installer.zip -qO /data/nexus.zip && \
+RUN wget --user-agent="Mozilla" https://github.com/Pathoschild/SMAPI/releases/download/4.1.10/SMAPI-4.1.10-installer.zip -qO /data/nexus.zip && \
     unzip /data/nexus.zip -d /data/nexus/ && \
     SMAPI_INSTALLER=$(find /data/nexus -name 'SMAPI*.*Installer' -type f -path "*/SMAPI * installer/internal/linux/*" | head -n 1) && \
     /bin/bash -c "SMAPI_NO_TERMINAL=true SMAPI_USE_CURRENT_SHELL=true echo -e '2\n\n' | \"$SMAPI_INSTALLER\" --install --game-path \"$GAME_PATH\"" || :


### PR DESCRIPTION
This PR updates SMAPI (Stardew Modding API) to the latest version.
## Changes

- Updated SMAPI  to 4.1.10

## Testing

I've been hosting multiplayer sessions with 5 other players (6 total including myself) since implementing these changes, and everything has been working smoothly. No stability issues or compatibility problems with our current mod setup.

## Notes

- Load times remain consistent with previous version
- All connected players report stable gameplay
- No conflicts detected with existing mods